### PR TITLE
docs: add guide for salted unique identifiers (OPRF)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -57,7 +57,7 @@ Parameters:
 - `projectID` (optional): The project ID of your service.
 - `validity` (optional): How many seconds ago the proof checking the ID's expiry date may have been generated. Defaults to 7 days.
 - `devMode` (optional): Whether to enable dev mode (defaults to false). Dev mode accepts mock proofs generated from the mock passports in the app.
-- `uniqueIdentifierType` (optional): `NullifierType.NON_SALTED` (default) or `NullifierType.SALTED`. A salted identifier requires `.facematch("strict")` in the query — see [Unlinkable Identifiers (OPRF)](./examples/unlinkable-identifiers).
+- `uniqueIdentifierType` (optional): `NullifierType.NON_SALTED` (default) or `NullifierType.SALTED`. A salted identifier requires `.facematch("strict")` in the query — see [Salted Unique Identifiers (OPRF)](./examples/salted-identifiers).
 - `oprfKeyId` (optional): OPRF key identifier; implies a salted unique identifier.
 - `topicOverride`, `keyPairOverride`, `cloudProverUrl`, `bridgeUrl` (optional): Advanced configuration. `cloudProverUrl` overrides the cloud prover for compressed proofs and `bridgeUrl` overrides the websocket bridge to the mobile app. Contact us if you need these.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -57,7 +57,7 @@ Parameters:
 - `projectID` (optional): The project ID of your service.
 - `validity` (optional): How many seconds ago the proof checking the ID's expiry date may have been generated. Defaults to 7 days.
 - `devMode` (optional): Whether to enable dev mode (defaults to false). Dev mode accepts mock proofs generated from the mock passports in the app.
-- `uniqueIdentifierType` (optional): `NullifierType.NON_SALTED` (default) or `NullifierType.SALTED`. A salted identifier requires `.facematch("strict")` in the query.
+- `uniqueIdentifierType` (optional): `NullifierType.NON_SALTED` (default) or `NullifierType.SALTED`. A salted identifier requires `.facematch("strict")` in the query — see [Unlinkable Identifiers (OPRF)](./examples/unlinkable-identifiers).
 - `oprfKeyId` (optional): OPRF key identifier; implies a salted unique identifier.
 - `topicOverride`, `keyPairOverride`, `cloudProverUrl`, `bridgeUrl` (optional): Advanced configuration. `cloudProverUrl` overrides the cloud prover for compressed proofs and `bridgeUrl` overrides the websocket bridge to the mobile app. Contact us if you need these.
 

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -14,3 +14,4 @@ If you are not entirely sure what you can do with the SDK, you can check some of
 - [Client-Server Implementation](./client-server.md) - See how to use the SDK on the client-side and verify proofs on the
   server-side
 - [Private FaceMatch](./facematch.md) - Verify the ID holder's face matches the ID photo
+- [Unlinkable Identifiers (OPRF)](./unlinkable-identifiers.md) - Get a unique identifier that nobody can link back to the user's ID

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -14,4 +14,4 @@ If you are not entirely sure what you can do with the SDK, you can check some of
 - [Client-Server Implementation](./client-server.md) - See how to use the SDK on the client-side and verify proofs on the
   server-side
 - [Private FaceMatch](./facematch.md) - Verify the ID holder's face matches the ID photo
-- [Unlinkable Identifiers (OPRF)](./unlinkable-identifiers.md) - Get a unique identifier that nobody can link back to the user's ID
+- [Salted Unique Identifiers (OPRF)](./salted-identifiers.md) - Get a unique identifier that cannot be linked back to the ID by the issuing entity

--- a/docs/examples/personhood.md
+++ b/docs/examples/personhood.md
@@ -13,7 +13,7 @@ Following this logic, you can use this as a base to check the personhood of the 
 
 - A person can have multiple IDs, so if you want to have `one person <-> one account` for example, it won't be exactly that but more `one ID <-> one account`.
 - If you want a truly robust proof of personhood, you should use [FaceMatch](./facematch.md) in your query. And for greater protection against spoofing, you should use the `strict` mode.
-- The default identifier can be recomputed by anyone with complete knowledge of the ID chip data — including the government that issued the ID. For increased privacy, request an [unlinkable identifier](./unlinkable-identifiers.md) instead, which nobody can link back to the user's ID.
+- The default identifier can be recomputed by anyone with complete knowledge of the ID chip data — including the government that issued the ID. For increased privacy, request a [salted unique identifier](./salted-identifiers.md) instead, which cannot be linked back to the ID by the issuing entity.
 
 ## Check uniqueness
 

--- a/docs/examples/personhood.md
+++ b/docs/examples/personhood.md
@@ -13,6 +13,7 @@ Following this logic, you can use this as a base to check the personhood of the 
 
 - A person can have multiple IDs, so if you want to have `one person <-> one account` for example, it won't be exactly that but more `one ID <-> one account`.
 - If you want a truly robust proof of personhood, you should use [FaceMatch](./facematch.md) in your query. And for greater protection against spoofing, you should use the `strict` mode.
+- The default identifier can be recomputed by anyone with complete knowledge of the ID chip data — including the government that issued the ID. For increased privacy, request an [unlinkable identifier](./unlinkable-identifiers.md) instead, which nobody can link back to the user's ID.
 
 ## Check uniqueness
 

--- a/docs/examples/salted-identifiers.md
+++ b/docs/examples/salted-identifiers.md
@@ -5,11 +5,11 @@ sidebar_position: 9
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Unlinkable Unique Identifiers (OPRF)
+# Salted Unique Identifiers (OPRF)
 
 Every verification result comes with a [unique identifier](./personhood.md) tied to the user's ID. By default, it is derived purely from the ID data, your domain, and the request scope — which means anyone with complete knowledge of the ID chip data (for example the government that issued the ID) could recompute it and recognize the user.
 
-**Unlinkable identifiers** — called *salted* identifiers in the API (`NullifierType.SALTED`) — close this gap. The user's device derives the identifier with the help of an extra secret (the "salt") held by an independent network of servers, using a technique called an OPRF (Oblivious Pseudo-Random Function):
+**Salted unique identifiers** (`NullifierType.SALTED`) close this gap. The user's device derives the identifier with the help of an extra secret (the "salt") held by an independent network of servers, using a technique called an OPRF (Oblivious Pseudo-Random Function):
 
 - The servers never see the user's data — they only receive a blinded value.
 - No single server holds the whole secret, so nobody can recompute the identifier on their own — not even with full knowledge of the ID data.
@@ -20,7 +20,7 @@ Use this when the identifier itself is sensitive — for example anonymous votin
 To request one:
 
 - Set `uniqueIdentifierType` to `NullifierType.SALTED` — available both on the SDK's `request()` method and as a prop on the `@zkpassport/ui` QR code component (shown below).
-- Add `.facematch("strict")` to your query. Unlinkable identifiers require the strict [FaceMatch](./facematch.md) mode, which confirms the ID is being used by its actual holder; the request throws an error without it.
+- Add `.facematch("strict")` to your query. Salted identifiers require the strict [FaceMatch](./facematch.md) mode, which confirms the ID is being used by its actual holder; the request throws an error without it.
 
 <Tabs groupId="framework">
 <TabItem value="react" label="React" default>
@@ -64,5 +64,5 @@ mount(document.getElementById("zkpassport"), {
 </Tabs>
 
 :::info
-The `onResult` callback also reports the identifier's type as `uniqueIdentifierType`. In [dev mode](../getting-started/dev-mode), mock proofs return `NullifierType.SALTED_MOCK` instead of `NullifierType.SALTED`, so you can tell real unlinkable identifiers apart from test ones.
+The `onResult` callback also reports the identifier's type as `uniqueIdentifierType`. In [dev mode](../getting-started/dev-mode), mock proofs return `NullifierType.SALTED_MOCK` instead of `NullifierType.SALTED`, so you can tell real salted identifiers apart from test ones.
 :::

--- a/docs/examples/unlinkable-identifiers.md
+++ b/docs/examples/unlinkable-identifiers.md
@@ -1,0 +1,68 @@
+---
+sidebar_position: 9
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Unlinkable Unique Identifiers (OPRF)
+
+Every verification result comes with a [unique identifier](./personhood.md) tied to the user's ID. By default, it is derived purely from the ID data, your domain, and the request scope — which means anyone with complete knowledge of the ID chip data (for example the government that issued the ID) could recompute it and recognize the user.
+
+**Unlinkable identifiers** — called *salted* identifiers in the API (`NullifierType.SALTED`) — close this gap. The user's device derives the identifier with the help of an extra secret (the "salt") held by an independent network of servers, using a technique called an OPRF (Oblivious Pseudo-Random Function):
+
+- The servers never see the user's data — they only receive a blinded value.
+- No single server holds the whole secret, so nobody can recompute the identifier on their own — not even with full knowledge of the ID data.
+- The result is still deterministic: the same ID yields the same identifier for your app, so you can still recognize returning users.
+
+Use this when the identifier itself is sensitive — for example anonymous voting, whistleblowing platforms, or any [personhood](./personhood.md) check where users must not be linkable to their real-world identity by anyone.
+
+To request one:
+
+- Set `uniqueIdentifierType` to `NullifierType.SALTED` — available both on the SDK's `request()` method and as a prop on the `@zkpassport/ui` QR code component (shown below).
+- Add `.facematch("strict")` to your query. Unlinkable identifiers require the strict [FaceMatch](./facematch.md) mode, which confirms the ID is being used by its actual holder; the request throws an error without it.
+
+<Tabs groupId="framework">
+<TabItem value="react" label="React" default>
+
+```tsx
+import { ZKPassportQRCode, NullifierType } from "@zkpassport/ui/react";
+
+<ZKPassportQRCode
+  name="ZKPassport"
+  logo="https://zkpassport.id/logo.png"
+  purpose="Prove your personhood"
+  scope="personhood"
+  uniqueIdentifierType={NullifierType.SALTED}
+  query={(queryBuilder) => queryBuilder.facematch("strict").done()}
+  onResult={({ verified, uniqueIdentifier }) => {
+    if (verified) console.log("Unique identifier", uniqueIdentifier);
+  }}
+/>;
+```
+
+</TabItem>
+<TabItem value="vanilla" label="Vanilla JS">
+
+```ts
+import { mount, NullifierType } from "@zkpassport/ui";
+
+mount(document.getElementById("zkpassport"), {
+  name: "ZKPassport",
+  logo: "https://zkpassport.id/logo.png",
+  purpose: "Prove your personhood",
+  scope: "personhood",
+  uniqueIdentifierType: NullifierType.SALTED,
+  query: (queryBuilder) => queryBuilder.facematch("strict").done(),
+  onResult: ({ verified, uniqueIdentifier }) => {
+    if (verified) console.log("Unique identifier", uniqueIdentifier);
+  },
+});
+```
+
+</TabItem>
+</Tabs>
+
+:::info
+The `onResult` callback also reports the identifier's type as `uniqueIdentifierType`. In [dev mode](../getting-started/dev-mode), mock proofs return `NullifierType.SALTED_MOCK` instead of `NullifierType.SALTED`, so you can tell real unlinkable identifiers apart from test ones.
+:::

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,7 +28,7 @@ No, ZKPassport is designed with privacy as a core principle. Your personal data 
 
 The unique identifier is derived from the ID data (retrieved from the chip). This data is combined with the domain name and the scope the service specified and hashed using Poseidon2. The resulting hash is used as the unique identifier. This ensures the unique identifier is the same for the same ID while differing between different services. And thanks to the one-way property of hash functions, it's not possible to derive the ID data from the unique identifier.
 
-However, it's possible to derive the unique identifier from the ID data if you have complete knowledge of the ID chip data, the domain name and scope. This could include the issuing government (if they keep a record of all the IDs they signed). In order to prevent this, we are currently working on supporting salted unique identifiers, i.e. adding a secret to the derivation process using vOPRFs (Verifiable Oblivious Pseudo-Random Functions).
+However, it's possible to derive the unique identifier from the ID data if you have complete knowledge of the ID chip data, the domain name and scope. This could include the issuing government (if they keep a record of all the IDs they signed). To prevent this, you can request an unlinkable (salted) unique identifier, which adds a secret to the derivation process using vOPRFs (Verifiable Oblivious Pseudo-Random Functions). See the [Unlinkable Identifiers](./examples/unlinkable-identifiers.md) example to learn how to use it.
 
 ### Which identity documents are supported?
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -28,7 +28,7 @@ No, ZKPassport is designed with privacy as a core principle. Your personal data 
 
 The unique identifier is derived from the ID data (retrieved from the chip). This data is combined with the domain name and the scope the service specified and hashed using Poseidon2. The resulting hash is used as the unique identifier. This ensures the unique identifier is the same for the same ID while differing between different services. And thanks to the one-way property of hash functions, it's not possible to derive the ID data from the unique identifier.
 
-However, it's possible to derive the unique identifier from the ID data if you have complete knowledge of the ID chip data, the domain name and scope. This could include the issuing government (if they keep a record of all the IDs they signed). To prevent this, you can request an unlinkable (salted) unique identifier, which adds a secret to the derivation process using vOPRFs (Verifiable Oblivious Pseudo-Random Functions). See the [Unlinkable Identifiers](./examples/unlinkable-identifiers.md) example to learn how to use it.
+However, it's possible to derive the unique identifier from the ID data if you have complete knowledge of the ID chip data, the domain name and scope. This could include the issuing government (if they keep a record of all the IDs they signed). To prevent this, you can request a salted unique identifier, which adds a secret to the derivation process using vOPRFs (Verifiable Oblivious Pseudo-Random Functions). See the [Salted Unique Identifiers](./examples/salted-identifiers.md) example to learn how to use it.
 
 ### Which identity documents are supported?
 

--- a/docs/getting-started/basic-usage.md
+++ b/docs/getting-started/basic-usage.md
@@ -235,6 +235,6 @@ onResult(({ verified, result, uniqueIdentifier }) => {
 - **`mode`** — the proof mode: `"fast"` (default), `"compressed"`, or `"compressed-evm"` (required for [onchain verification](./onchain)).
 - **`validity`** — how many seconds ago the proof checking the ID's expiry date may have been generated. Defaults to 7 days.
 - **`devMode`** — accept mock proofs from the dev-mode passports. See [Dev Mode](./dev-mode).
-- **`uniqueIdentifierType`** / **`oprfKeyId`** — opt into a salted unique identifier. A salted identifier requires `.facematch("strict")` in the query.
+- **`uniqueIdentifierType`** / **`oprfKeyId`** — opt into a salted unique identifier. A salted identifier requires `.facematch("strict")` in the query. See [Unlinkable Identifiers (OPRF)](../examples/unlinkable-identifiers).
 
 See the [API Reference](../api) for the complete list and exact types.

--- a/docs/getting-started/basic-usage.md
+++ b/docs/getting-started/basic-usage.md
@@ -235,6 +235,6 @@ onResult(({ verified, result, uniqueIdentifier }) => {
 - **`mode`** — the proof mode: `"fast"` (default), `"compressed"`, or `"compressed-evm"` (required for [onchain verification](./onchain)).
 - **`validity`** — how many seconds ago the proof checking the ID's expiry date may have been generated. Defaults to 7 days.
 - **`devMode`** — accept mock proofs from the dev-mode passports. See [Dev Mode](./dev-mode).
-- **`uniqueIdentifierType`** / **`oprfKeyId`** — opt into a salted unique identifier. A salted identifier requires `.facematch("strict")` in the query. See [Unlinkable Identifiers (OPRF)](../examples/unlinkable-identifiers).
+- **`uniqueIdentifierType`** / **`oprfKeyId`** — opt into a salted unique identifier. A salted identifier requires `.facematch("strict")` in the query. See [Salted Unique Identifiers (OPRF)](../examples/salted-identifiers).
 
 See the [API Reference](../api) for the complete list and exact types.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -51,8 +51,8 @@ const sidebars: SidebarsConfig = {
         },
         {
           type: "doc",
-          label: "Unlinkable Identifiers",
-          id: "examples/unlinkable-identifiers",
+          label: "Salted Unique Identifiers",
+          id: "examples/salted-identifiers",
         },
       ],
     },

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -49,6 +49,11 @@ const sidebars: SidebarsConfig = {
           label: "Private FaceMatch",
           id: "examples/facematch",
         },
+        {
+          type: "doc",
+          label: "Unlinkable Identifiers",
+          id: "examples/unlinkable-identifiers",
+        },
       ],
     },
     "api",


### PR DESCRIPTION
Adds an example page explaining salted unique identifiers in plain language, with QR-component usage (`uniqueIdentifierType` + strict FaceMatch), and links to it from the FAQ, API reference, basic usage, and personhood pages. Also updates the stale FAQ note that said salted identifiers were still in the works.